### PR TITLE
feat: Add Release Automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: release
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+      - name: validate gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+      - name: setup jdk
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'microsoft'
+      - name: make gradle wrapper executable
+        run: chmod +x ./gradlew
+      - name: verify version
+        run: |
+          # Extract version from tag (remove 'v' prefix if present)
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          
+          # Extract version from gradle.properties
+          GRADLE_VERSION=$(grep "mod_version=" gradle.properties | cut -d'=' -f2 | tr -d '[:space:]')
+          
+          echo "Tag Version: $TAG_VERSION"
+          echo "Gradle Version: $GRADLE_VERSION"
+          
+          if [ "$TAG_VERSION" != "$GRADLE_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match gradle.properties version ($GRADLE_VERSION)"
+            exit 1
+          fi
+      - name: build
+        run: ./gradlew build
+      - name: upload release asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} build/libs/*.jar

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ We welcome contributions! If you're interested in helping improve Screenshot Man
 
 Please report any bugs or feature requests on the [Issue Tracker](https://github.com/milezerosoftware/screenshot-manager-enhanced/issues).
 
+## 🚀 Release Process
+
+To create a new release:
+
+1. Update `mod_version` in `gradle.properties` (e.g., `1.0.0`).
+2. Commit and push the changes.
+3. Create a new GitHub Release with a tag matching the version (e.g., `v1.0.0`).
+4. The GitHub Action will automatically build and upload the release JAR.
+
+> [!IMPORTANT]
+> The tag name must match the `mod_version` in `gradle.properties` (ignoring the `v` prefix). If they do not match, the build will fail.
+
 ## 📄 License
 
 This project is licensed under the [Apache-2.0 License](LICENSE).

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,8 @@ plugins {
 def getVersionSuffix() {
 	// CI Environment
 	if (System.getenv("GITHUB_ACTIONS")) {
-		if (System.getenv("GITHUB_REF") == "refs/heads/main") {
+		def ref = System.getenv("GITHUB_REF")
+		if (ref == "refs/heads/main" || (ref != null && ref.startsWith("refs/tags/"))) {
 			return ""
 		}
 		return "-SNAPSHOT"


### PR DESCRIPTION
## 🔗 Related Issue

Closes #35 

---

## 🌟 What's in this Pull Request?

This PR implements a GitHub Action workflow to automate the release process. When a release is published in GitHub, this workflow builds the project (ensuring the version matches the tag) and uploads the release JAR artifact. It also updates `build.gradle` to produce clean filenames (removing the `-SNAPSHOT` suffix) for tagged releases.

---

## 💻 Technical Details

- **Added:** `.github/workflows/release.yml` - Workflow definition for automated releases.
- **Modified:** `build.gradle` - Updated version suffix logic to support release tags.
- **Modified:** `README.md` - Added Release Process documentation.

---

## ✅ Checklist for Review

- [x] **Code Quality:** My code adheres to the project's coding standards and style guide.
- [ ] **Tests:** New or updated unit/integration tests have been added to cover the changes. (N/A - CI logic)
- [x] **Functionality:** I have manually tested the changes and they work as expected.
- [x] **Documentation:** I have updated relevant documentation (e.g., API docs, README) if my changes require it.
- [x] **Dependencies:** I have checked for and updated any necessary dependencies.
- [x] **No Regression:** My changes do not break existing functionality.

---

## 🧪 How to Test These Changes

1.  Pull this branch: `git checkout feature/release-automation`
2.  **Verify Build Logic**:
    ```bash
    export GITHUB_ACTIONS=true
    export GITHUB_REF=refs/tags/v1.0.0
    # Ensure gradle.properties has mod_version=1.0.0
    ./gradlew properties | grep version
    # Should output version: 1.0.0 (no -SNAPSHOT)
    ```
3.  **Verify Workflow**: Review `.github/workflows/release.yml`.

### ✨ Test Environment

N/A - CI Workflow

---

## 📸 Screenshots & Recordings

N/A - CI/CD change.

---

## 📝 Additional Notes

The workflow includes a safety check to fail the build if the git tag does not match the `mod_version` in `gradle.properties`.
