### PR TITLE
perf: Skip sources jar generation in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build
-        run: ./gradlew :fabric:build -Pmc_ver=${{ matrix.mc_ver }}
+        run: ./gradlew :fabric:build -Pmc_ver=${{ matrix.mc_ver }} -PskipSources=true
       - name: upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -101,8 +101,10 @@ tasks.withType(JavaCompile).configureEach {
 java {
 	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
 	// if it is present.
-	// If you remove this line, sources will not be generated.
-	withSourcesJar()
+	// Skip sources jar generation when -PskipSources=true is passed (e.g., for release builds)
+	if (!project.hasProperty('skipSources') || project.property('skipSources') != 'true') {
+		withSourcesJar()
+	}
 
 	sourceCompatibility = JavaVersion.VERSION_21
 	targetCompatibility = JavaVersion.VERSION_21


### PR DESCRIPTION
## 🔗 Related Issue

Relates to #55 

---

## 🌟 What's in this Pull Request?

- changed to not build -sources.jar

---

## 💻 Technical Details

---

## ✅ Checklist for Review

(This checklist ensures all necessary steps have been taken before merging and provides a quick way for the reviewer to verify the work. Leave checkboxes as [ ] unless the task is completed.)

- [x] **Code Quality:** My code adheres to the project's coding standards and style guide.
- [ ] **Tests:** New or updated unit/integration tests have been added to cover the changes.
- [ ] **Functionality:** I have manually tested the changes and they work as expected.
- [ ] **Documentation:** I have updated relevant documentation (e.g., API docs, README) if my changes require it.
- [ ] **Dependencies:** I have checked for and updated any necessary dependencies.
- [x] **No Regression:** My changes do not break existing functionality.

---

## 🧪 How to Test These Changes

### ✨ Test Environment

(add_url_here)

#### Reason for no test environment:

- [ ] Under feature flag
- [ ] Going into feature branch
- [x] Not user facing
- [ ] Other, please explain:

---

## 📸 Screenshots & Recordings

(If there are any visual changes, provide screenshots or a short video to demonstrate the new functionality or fixes. This is a crucial step for visual confirmation.)

<!-- LLM: If you cannot provide a direct attachment, state that attachments must be manually uploaded to the GitHub issue after creation. -->

(Drag and drop images here or provide a link after issue creation.)

---

## 📝 Additional Notes

(Any other information that could be helpful, such as known issues, potential side effects, or a summary of a design conversation.)

---
